### PR TITLE
Created Guzzle response handling

### DIFF
--- a/src/XmlStringStreamer/Stream/Guzzle/Response.php
+++ b/src/XmlStringStreamer/Stream/Guzzle/Response.php
@@ -19,11 +19,11 @@ class Response implements StreamInterface
     /** @var callable|null */
     private $chunkCallback;
 
-    public function __construct( \GuzzleHttp\Psr7\Response $response, $chunkSize = 1024, $chunkCallback = null )
+    public function __construct(\GuzzleHttp\Psr7\Response $response, $chunkSize = 1024, $chunkCallback = null)
     {
         $this->chunkSize = $chunkSize;
         $this->chunkCallback = $chunkCallback;
-        $this->stream = $response->getBody(); #lets get the body stream
+        $this->stream = $response->getBody(); //lets get the body stream
     }
 
     public function setGuzzleStream($stream)
@@ -33,7 +33,7 @@ class Response implements StreamInterface
 
     public function getChunk()
     {
-        if (! $this->stream->eof()) {
+        if (!$this->stream->eof()) {
             $buffer = $this->stream->read($this->chunkSize);
             $this->readBytes += strlen($buffer);
 
@@ -55,7 +55,7 @@ class Response implements StreamInterface
     public function rewind()
     {
         if ($this->isSeekable() === false) {
-            throw new Exception("Attempted to rewind an unseekable stream.");
+            throw new Exception('Attempted to rewind an unseekable stream.');
         }
 
         $this->readBytes = 0;

--- a/src/XmlStringStreamer/Stream/Guzzle/Response.php
+++ b/src/XmlStringStreamer/Stream/Guzzle/Response.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Prewk\XmlStringStreamer\Stream\Guzzle;
+
+use Exception;
+use Prewk\XmlStringStreamer\StreamInterface;
+
+class Response implements StreamInterface
+{
+    /** @var StreamInterface */
+    private $stream;
+
+    /** @var int */
+    private $readBytes = 0;
+
+    /** @var int */
+    private $chunkSize;
+
+    /** @var callable|null */
+    private $chunkCallback;
+
+    public function __construct( \GuzzleHttp\Psr7\Response $response, $chunkSize = 1024, $chunkCallback = null )
+    {
+        $this->chunkSize = $chunkSize;
+        $this->chunkCallback = $chunkCallback;
+        $this->stream = $response->getBody(); #lets get the body stream
+    }
+
+    public function setGuzzleStream($stream)
+    {
+        $this->stream = $stream;
+    }
+
+    public function getChunk()
+    {
+        if (! $this->stream->eof()) {
+            $buffer = $this->stream->read($this->chunkSize);
+            $this->readBytes += strlen($buffer);
+
+            if (is_callable($this->chunkCallback)) {
+                call_user_func_array($this->chunkCallback, [$buffer, $this->readBytes]);
+            }
+
+            return $buffer;
+        } else {
+            return false;
+        }
+    }
+
+    public function isSeekable()
+    {
+        return $this->stream->isSeekable();
+    }
+
+    public function rewind()
+    {
+        if ($this->isSeekable() === false) {
+            throw new Exception("Attempted to rewind an unseekable stream.");
+        }
+
+        $this->readBytes = 0;
+        $this->stream->rewind();
+    }
+}


### PR DESCRIPTION
There can be edge cases where there is need to leverage the Guzzle\Response. More specifically for situations where there is a need to create custom clients.

### Examples
```php

use GuzzleHttp\Client;
use GuzzleHttp\Psr7\Response;
use Prewk\XmlStringStreamer;
use Prewk\XmlStringStreamer\Stream;
use Prewk\XmlStringStreamer\Parser;

$client = new GuzzleHttp\Client( );
$response = $client->request( 'GET',  'https://some-bigdata-xml-service/user',  [
    'auth' => [ 'username', 'password', 'digest' ],
]);

$CHUNK_SIZE = 1024;

$stream = new Stream\Guzzle\Response( $response, $CHUNK_SIZE );
$parser = new Parser\StringWalker( );

$streamer = new XmlStringStreamer( $parser, $stream );

while ( $node = $streamer->getNode() )
{
	// ...
}```


fixes https://github.com/prewk/xml-string-streamer-guzzle/issues/8