### PR TITLE
Fix Guzzle PSR7 deleted function stream_for

### DIFF
--- a/src/XmlStringStreamer/Stream/Guzzle.php
+++ b/src/XmlStringStreamer/Stream/Guzzle.php
@@ -25,7 +25,7 @@ class Guzzle implements StreamInterface
         $this->chunkSize = $chunkSize;
         $this->chunkCallback = $chunkCallback;
         $this->stream = new Psr7\CachingStream(
-            Psr7\stream_for(fopen($url, 'r'))
+            Psr7\Utils::streamFor(fopen($url, 'r'))
         );
     }
 

--- a/tests/Integration/GuzzleTest.php
+++ b/tests/Integration/GuzzleTest.php
@@ -4,7 +4,7 @@ namespace Tests\Integration;
 
 use Exception;
 use GuzzleHttp\Psr7\NoSeekStream;
-use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Prewk\XmlStringStreamer\Stream\Guzzle;
 
@@ -49,7 +49,7 @@ class GuzzleTest extends TestCase
         $stream = new Guzzle($this->source);
 
         $stream->setGuzzleStream(
-            new NoSeekStream(stream_for($this->source))
+            new NoSeekStream(Utils::streamFor($this->source))
         );
 
         $stream->rewind();
@@ -69,7 +69,7 @@ class GuzzleTest extends TestCase
         $stream = new Guzzle($this->source);
 
         $stream->setGuzzleStream(
-            new NoSeekStream(stream_for($this->source))
+            new NoSeekStream(Utils::streamFor($this->source))
         );
 
         $this->assertFalse($stream->isSeekable());


### PR DESCRIPTION
Guzzle\PSR7\stream_for has been deleted from new Guzzle\PSR7 2.0.0 package and replaced by Guzzle\PSR7\Utils::streamFor
Tests is passing, i haven't tested it in live, it is working if we fix the version of Guzzle\PSR7 to version 1.8.2